### PR TITLE
chore: switch to platforms in charmcraft.yaml

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,9 +12,8 @@ summary: An integrator charm for configuring ldap clients.
 description: |
   An integrator charm for configuring ldap clients.
 
-base: ubuntu@22.04
 platforms:
-  amd64:
+  ubuntu@22.04:amd64:
 
 provides:
   ldap:


### PR DESCRIPTION
This PR changes the charm's charmcraft `base` to `platforms`. This is a prerequisite to add main branch to charmcraftcache builds and switch to reusable workflows.

blocked by https://github.com/canonical/ldap-integrator/issues/62