### PR TITLE
feat: update tf module to comply with CC008 specification

### DIFF
--- a/terraform/MODULE_SPECS.md
+++ b/terraform/MODULE_SPECS.md
@@ -5,32 +5,33 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.0.0 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | ~> 1.0 |
 ---
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6 |
-| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 1.0.0 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.0 |
 ---
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | UUID of the Juju model to deploy to | `string` | n/a | yes |
-| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the application | `string` | `"ldap-integrator"` | no |
-| <a name="input_base"></a> [base](#input\_base) | The charm base | `string` | `"ubuntu@22.04"` | no |
-| <a name="input_channel"></a> [channel](#input\_channel) | Channel to use for the charm | `string` | `"latest/stable"` | no |
-| <a name="input_config"></a> [config](#input\_config) | The charm config | `map(string)` | `{}` | no |
-| <a name="input_constraints"></a> [constraints](#input\_constraints) | The constraints to be applied | `string` | `""` | no |
-| <a name="input_revision"></a> [revision](#input\_revision) | Revision of the charm to deploy | `number` | `null` | no |
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the application in the Juju model | `string` | `"ldap-integrator"` | no |
+| <a name="input_base"></a> [base](#input\_base) | Operating system base for the charm (e.g. ubuntu@22.04) | `string` | `null` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | Channel to use when deploying the charm | `string` | `"latest/stable"` | no |
+| <a name="input_config"></a> [config](#input\_config) | Map of charm configuration options | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | Constraints string for the deployed application | `string` | `null` | no |
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | UUID of the Juju model to deploy the charm into | `string` | n/a | yes |
+| <a name="input_revision"></a> [revision](#input\_revision) | Charm revision to deploy. Null deploys the latest on the given channel | `number` | `null` | no |
 | <a name="input_units"></a> [units](#input\_units) | Number of units to deploy | `number` | `1` | no |
 ---
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | The name of the deployed application |
-| <a name="output_provides"></a> [provides](#output\_provides) | The Juju integrations that the charm provides |
+| <a name="output_application"></a> [application](#output\_application) | The deployed juju\_application resource |
+| <a name="output_provides"></a> [provides](#output\_provides) | Map of provides endpoint names |
 <!-- END_TF_DOCS -->
+

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,13 +1,13 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-output "app_name" {
-  description = "The name of the deployed application"
-  value       = juju_application.ldap_integrator.name
+output "application" {
+  description = "The deployed juju_application resource"
+  value       = juju_application.ldap_integrator
 }
 
 output "provides" {
-  description = "The Juju integrations that the charm provides"
+  description = "Map of provides endpoint names"
   value = {
     ldap = "ldap"
   }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,4 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+provider "juju" {}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 1.0.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,43 +1,44 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-variable "model_uuid" {
-  description = "UUID of the Juju model to deploy to"
-  type        = string
-}
-
 variable "app_name" {
-  description = "Name of the application"
+  description = "Name of the application in the Juju model"
   type        = string
   default     = "ldap-integrator"
 }
 
 variable "base" {
-  description = "The charm base"
+  description = "Operating system base for the charm (e.g. ubuntu@22.04)"
   type        = string
-  default     = "ubuntu@22.04"
+  default     = null
 }
 
 variable "channel" {
-  description = "Channel to use for the charm"
+  description = "Channel to use when deploying the charm"
   type        = string
   default     = "latest/stable"
 }
 
 variable "config" {
-  description = "The charm config"
+  description = "Map of charm configuration options"
   type        = map(string)
   default     = {}
 }
 
 variable "constraints" {
-  description = "The constraints to be applied"
+  description = "Constraints string for the deployed application"
   type        = string
-  default     = ""
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "UUID of the Juju model to deploy the charm into"
+  type        = string
+  nullable    = false
 }
 
 variable "revision" {
-  description = "Revision of the charm to deploy"
+  description = "Charm revision to deploy. Null deploys the latest on the given channel"
   type        = number
   default     = null
 }


### PR DESCRIPTION
This PR updates the Terraform module for `ldap-integrator` to be compliant with the updated [CC008](https://docs.google.com/document/d/1k1psLCfcf0Nr5KeVtWGFi9wmzhcg5AP9GVZTsRyVQSQ/edit?usp=sharing) specification.

The most noticeable change is that the entire `juju_application` resource is now provided as an output rather than just the application name.